### PR TITLE
feat: Typst

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,17 @@
 FROM ghcr.io/csunibo/statik:latest as statik
 
 FROM alpine
-RUN apk add --no-cache tectonic libreoffice pandoc ruby xournalpp git git-lfs ruby-dev build-base
+RUN apk add --no-cache \
+    build-base
+    git
+    git-lfs
+    libreoffice
+    pandoc
+    ruby
+    ruby-dev
+    tectonic
+    typst
+    xournalpp
 RUN gem install --no-document asciidoctor-pdf asciidoctor
 RUN apk del ruby-dev build-base
 COPY --from=statik /usr/bin/statik /usr/bin/statik

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,15 @@ FROM ghcr.io/csunibo/statik:latest as statik
 
 FROM alpine
 RUN apk add --no-cache \
-    build-base
-    git
-    git-lfs
-    libreoffice
-    pandoc
-    ruby
-    ruby-dev
-    tectonic
-    typst
+    build-base \
+    git \
+    git-lfs \
+    libreoffice \
+    pandoc \
+    ruby \
+    ruby-dev \
+    tectonic \
+    typst \
     xournalpp
 RUN gem install --no-document asciidoctor-pdf asciidoctor
 RUN apk del ruby-dev build-base

--- a/README.adoc
+++ b/README.adoc
@@ -1,11 +1,13 @@
 = Immagine OCI per la build dei repository
 
-Questo repository contiene i file che servono per la costruzione dell'immagine utilizzata per buildare i repository delle materie di csunibo.
+Questo repository contiene i file che servono per la costruzione dell'immagine
+utilizzata per buildare i repository delle materie di csunibo.
 
 .L'immagine attualmente contiene:
 * https://github.com/lucat1/statik[Statik]
 * pandoc
 * tectonic
+* typst
 * libreoffice
 * asciidoctor
 * xournalpp


### PR DESCRIPTION
Closes #7. Needs to wait for https://hub.docker.com/_/alpine to tag 3.20 before merge. Until then, CI/CD will fail as typst is not available on Alpine 3.19 stable.

The Docker image should be available "(early?) next week":

https://fosstodon.org/@ncopa/112456174313716049