### PR TITLE
fix: add fonts for missing codepoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache \
     font-noto-emoji \
     font-noto-hebrew \
     font-noto-math \
-    font-noto-symbols \
+    font-noto-symbols
 RUN gem install --no-document asciidoctor-pdf asciidoctor
 RUN python3 -m venv /opt/venv
 RUN /opt/venv/bin/pip install jupyter

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,12 @@ RUN apk add --no-cache \
     gcc \
     python3-dev \
     musl-dev \
-    linux-headers
+    linux-headers \
+    font-noto-cjk-extra \
+    font-noto-emoji \
+    font-noto-hebrew \
+    font-noto-math \
+    font-noto-symbols \
 RUN gem install --no-document asciidoctor-pdf asciidoctor
 RUN python3 -m venv /opt/venv
 RUN /opt/venv/bin/pip install jupyter


### PR DESCRIPTION
Closes #3 by adding the missing fonts.

I run LibreOffice within the `build-image` container locally before and after installing the fonts. I only tested the first PDF from `storia-informatica-e-dispositivi-di-calcolo`, which was fixed by this patch.