### PR TITLE
feat: biber

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apk add --no-cache \
     ruby \
     ruby-dev \
     tectonic \
+    biber \
     typst \
     xournalpp \
     gcc \

--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,7 @@ Immagine usata per convertire le risorse degli insegnamenti di CartaBinaria.
 .L'immagine attualmente contiene:
 * https://github.com/cartabinaria/statik[Statik]
 * pandoc
-* tectonic
+* tectonic (and biber)
 * typst
 * libreoffice
 * asciidoctor


### PR DESCRIPTION
Adds the `biber` package. Biber is the default backend for biblatex. Triggered by: https://github.com/cartabinaria/modelli-probabilistici/pull/1